### PR TITLE
Chore/1 upgrade gems #1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,8 +60,6 @@ GEM
     childprocess (0.6.3)
       ffi (~> 1.0, >= 1.0.11)
     climate_control (0.2.0)
-    cocaine (0.5.8)
-      climate_control (>= 0.0.3, < 1.0)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.2.x)
@@ -115,12 +113,12 @@ GEM
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
-    paperclip (5.1.0)
+    paperclip (6.1.0)
       activemodel (>= 4.2.0)
       activesupport (>= 4.2.0)
-      cocaine (~> 0.5.5)
       mime-types
       mimemagic (~> 0.3.0)
+      terrapin (~> 0.6.0)
     public_suffix (2.0.5)
     puma (3.8.2)
     rack (2.0.5)
@@ -182,6 +180,8 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
+    terrapin (0.6.0)
+      climate_control (>= 0.0.3, < 1.0)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.7)
@@ -234,4 +234,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.14.6
+   1.16.1


### PR DESCRIPTION
upgrade 2 gems

- paperclip
- sprockets

```
Name: paperclip
Version: 5.1.0
Advisory: CVE-2017-0889
Criticality: High
URL: https://github.com/thoughtbot/paperclip/pull/2435
Title: Paperclip ruby gem suffers from a Server-Side Request Forgery (SSRF) vulnerability
in the Paperclip::UriAdapter and Paperclip::HttpUrlProxyAdapter class.
Solution: upgrade to >= 5.2.0

Name: rubyzip
Version: 1.2.1
Advisory: CVE-2018-1000544
Criticality: Unknown
URL: https://github.com/rubyzip/rubyzip/issues/369
Title: Directory Traversal in rubyzip
Solution: remove or disable this gem until a patch is available!

Name: sprockets
Version: 3.7.1
Advisory: CVE-2018-3760
Criticality: Unknown
URL: https://groups.google.com/forum/#!topic/ruby-security-ann/2S9Pwz2i16k
Title: Path Traversal in Sprockets
Solution: upgrade to < 3.0.0
```