### PR TITLE
upgrade rubyzip gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     sass (3.4.23)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)


### PR DESCRIPTION
bundle update rubyzip --conservative

```
We found a potential security vulnerability in a repository for which you have been granted security alert access.

@shtakai	shtakai/rspec-retrospective
Known moderate severity security vulnerability detected in rubyzip <= 1.2.1 defined in Gemfile.lock.
Gemfile.lock update suggested: rubyzip ~> 1.2.2.
Always verify the validity and compatibility of suggestions with your codebase.
```